### PR TITLE
fix deprecated use of autowired ContainerInterface in ControllerReflector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2020-07-27
+### Fixed
+* Deprecation introduced with Symfony 5.1: Autowiring ContainerInterface will be dropped in 6.x 
+
 ## [2.0.0] - 2020-03-20
 ### Added
 * Support for Symfony 5.0

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -1,3 +1,4 @@
 services:
-  Shopping\ApiTKCommonBundle\Util\ControllerReflector:
-    autowire: true
+    Shopping\ApiTKCommonBundle\Util\ControllerReflector:
+        arguments:
+            $container: '@service_container'

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "check24/apitk-common-bundle",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "type": "symfony-bundle",
   "description": "",


### PR DESCRIPTION
Fixes the following Deprecation in Symfony 5.1:
![Bildschirmfoto 2020-07-20 um 16 41 01](https://user-images.githubusercontent.com/690188/87951381-c8c6a700-caa8-11ea-9e31-6c80e338a045.png)
