### PR TITLE
Add support for sensio/framework-extra-bundle 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2021-08-30
+
+### Added
+
+- Support for sensio/framework-extra-bundle 6.x
+
 ## [2.1.0] - 2021-06-28
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^7.1.3 || ^8.0",
         "nelmio/api-doc-bundle": "^3.2",
-        "sensio/framework-extra-bundle": "^5.2",
+        "sensio/framework-extra-bundle": "^5.2 || ^6.0",
         "symfony/config": ">= 4.3 <6.0",
         "symfony/dependency-injection": ">= 4.3 <6.0",
         "symfony/framework-bundle": ">= 4.3 <6.0"


### PR DESCRIPTION
sensio/framework-extra-bundle did remove the dependency on `nyholm/psr7` in 6.x, which this bundle does not rely upon.
See https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/CHANGELOG.md

This change allows implementing projects to use the most recent version of sensio/framework-extra-bundle again.